### PR TITLE
Fix new empty file misclassified as renamed when another empty file e…

### DIFF
--- a/source/server/app_base.rb
+++ b/source/server/app_base.rb
@@ -11,6 +11,7 @@ class AppBase < Sinatra::Base
   end
 
   silently { register Sinatra::Contrib } # respond_to
+  set :json_encoder, Sinatra::JSON       # avoids MultiJson.encode deprecation warning
   set :port, ENV['PORT']
 
   def self.get_json(name, klass)

--- a/source/server/external/gitter.rb
+++ b/source/server/external/gitter.rb
@@ -50,7 +50,7 @@ module External
       '--unified=99999999999',
       '--no-prefix',
       '--ignore-space-at-eol',
-      '--find-copies-harder',
+      '--find-renames',
       '--indent-heuristic',
       '0',
       '1',

--- a/source/server/git_diff_parse_filenames.rb
+++ b/source/server/git_diff_parse_filenames.rb
@@ -3,6 +3,7 @@ module GitDiffParseFilenames
     old_filename, new_filename = old_new_filenames(header[0])
     new_filename = nil if header[1].start_with?('deleted file mode')
     old_filename = nil if header[1].start_with?('new file mode')
+    old_filename = nil if header[2]&.start_with?('copy from')
     [old_filename, new_filename]
   end
 

--- a/test/server/external_gitter_test.rb
+++ b/test/server/external_gitter_test.rb
@@ -57,7 +57,7 @@ class ExternalGitterTest < DifferTestBase
       '--unified=99999999999',
       '--no-prefix',
       '--ignore-space-at-eol',
-      '--find-copies-harder',
+      '--find-renames',
       '--indent-heuristic',
       '0',
       '1',

--- a/test/server/git_diff_parse_filenames_test.rb
+++ b/test/server/git_diff_parse_filenames_test.rb
@@ -191,5 +191,27 @@ class GitDiffParseFilenamesTest < DifferTestBase
     assert_equal 'b/u/i/o/em bed"ded', new_filename, :new_filename
   end
 
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'wK7C3F', %w(
+  | old_filename is nil for copied file.
+  | git diff --find-copies-harder (used in gitter.rb) enables copy
+  | detection across unmodified files. All empty files share the same
+  | blob hash (e69de29), so when a new empty file is added alongside
+  | an existing empty file, git sees two files with identical content
+  | and emits copy from/to headers instead of new file mode.
+  | The parser must treat this as :created, not :renamed.
+  ) do
+    header = [
+      'diff --git empty.txt new_file.txt',
+      'similarity index 100%',
+      'copy from empty.txt',
+      'copy to new_file.txt'
+    ]
+    old_filename, new_filename = parse_old_new_filenames(header)
+    assert_nil old_filename, :old_filename
+    assert_equal 'new_file.txt', new_filename, :new_filename
+  end
+
   include GitDiffParseFilenames
 end

--- a/test/server/lib/coverage_metrics_limits.rb
+++ b/test/server/lib/coverage_metrics_limits.rb
@@ -1,14 +1,14 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 526 ],
+    [ 'test.lines.total'    , '<=', 531 ],
     [ 'test.lines.missed'   , '<=', 0   ],
     [ 'test.branches.total' , '<=', 0   ],
     [ 'test.branches.missed', '<=', 0   ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 351 ],
+    [ 'code.lines.total'    , '<=', 352 ],
     [ 'code.lines.missed'   , '<=', 0   ],
-    [ 'code.branches.total' , '<=', 58  ],
+    [ 'code.branches.total' , '<=', 62  ],
     [ 'code.branches.missed', '<=', 0   ],
   ]
 end

--- a/test/server/lib/test_metrics_limits.rb
+++ b/test/server/lib/test_metrics_limits.rb
@@ -1,7 +1,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 106 ],
+    [ 'test_count',    '>=', 107 ],
     [ 'total_time',    '<=',  75 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],


### PR DESCRIPTION
…xists

git diff --find-copies-harder considers unmodified files as copy sources. Since all empty files share blob hash e69de29, adding a new empty file alongside an existing one causes git to emit copy from/to headers rather than new file mode. The parser had no copy header handling, so it fell through to the old != new filename branch and returned :renamed.

Fix: replace --find-copies-harder with --find-renames in the git diff command (preserving rename detection, dropping copy detection), and add a copy-header guard in parse_old_new_filenames as defence in depth.