### PR TITLE
Remove approve-deployment-to-beta job as report approval is deprecated

### DIFF
--- a/.github/workflows/force-ci-run
+++ b/.github/workflows/force-ci-run
@@ -1,2 +1,2 @@
 Edit this file for a quick way to force a CI run
-185
+186

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -330,38 +330,8 @@ jobs:
             --environment=${KOSLI_AWS_BETA}
 
 
-  approve-deployment-to-beta:
-    runs-on: ubuntu-latest
-    needs: [build-image, sdlc-control-gate]
-    env:
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
-    environment:
-      name: staging
-      url:  https://beta.cyber-dojo.org
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@v3
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION }}
-
-      - name: Attest approval of deployment to Kosli
-        run:
-          kosli report approval
-            --approver="${{ github.actor }}"
-            --environment=${KOSLI_AWS_BETA}
-
-
   deploy-to-beta:
-    needs: [setup, build-image, approve-deployment-to-beta]
+    needs: [setup, build-image]
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
kosli report approval is deprecated, so the manual approval gate before deploying to beta has been removed and deploy-to-beta no longer depends on it.