### PR TITLE
Remove manual approval gate for beta deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -330,38 +330,8 @@ jobs:
             --environment=${KOSLI_AWS_BETA}
 
 
-  approve-deployment-to-beta:
-    runs-on: ubuntu-latest
-    needs: [build-image, sdlc-control-gate]
-    env:
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
-    environment:
-      name: staging
-      url:  https://beta.cyber-dojo.org
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Kosli CLI
-        uses: kosli-dev/setup-cli-action@v3
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION }}
-
-      - name: Attest approval of deployment to Kosli
-        run:
-          kosli report approval
-            --approver="${{ github.actor }}"
-            --environment=${KOSLI_AWS_BETA}
-
-
   deploy-to-beta:
-    needs: [setup, build-image, approve-deployment-to-beta]
+    needs: [setup, build-image, sdlc-control-gate]
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
The approve-deployment-to-beta job required a human to explicitly approve via a GitHub environment before the deploy-to-beta job could run. This removes that gate and instead makes deploy-to-beta depend directly on sdlc-control-gate, which already performs the automated compliance check via Kosli.