### PR TITLE
Introduce diff_lines_files/diff_summary_files as the core diff API

### DIFF
--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -13,6 +13,6 @@ copy_in_saver_test_data
 TMP_HTML_FILENAME=/tmp/differ-demo.html
 docker exec \
   "${CYBER_DOJO_DIFFER_CLIENT_CONTAINER_NAME}" \
-    sh -c 'ruby /differ/html_demo.rb' \
+    sh -c 'ruby /differ/source/html_demo.rb' \
       > ${TMP_HTML_FILENAME}
 open "file://${TMP_HTML_FILENAME}"

--- a/source/server/differ.rb
+++ b/source/server/differ.rb
@@ -7,21 +7,29 @@ class Differ
   end
 
   def diff_lines(id:, was_index:, now_index:)
-    diff_plus(id, was_index, now_index, lines: true)
+    was_files = files(saver.kata_event(id, was_index))
+    now_files = files(saver.kata_event(id, now_index))
+    diff_lines_files(was_files: was_files, now_files: now_files)
   end
 
   def diff_summary(id:, was_index:, now_index:)
-    diff_plus(id, was_index, now_index, lines: false)
+    was_files = files(saver.kata_event(id, was_index))
+    now_files = files(saver.kata_event(id, now_index))
+    diff_summary_files(was_files: was_files, now_files: now_files)
+  end
+
+  def diff_lines_files(was_files:, now_files:)
+    diff_plus(was_files, now_files, lines: true)
+  end
+
+  def diff_summary_files(was_files:, now_files:)
+    diff_plus(was_files, now_files, lines: false)
   end
 
   private
 
-  def diff_plus(id, was_index, now_index, options)
-    was = saver.kata_event(id, was_index)
-    now = saver.kata_event(id, now_index)
-    was_files = files(was)
-    now_files = files(now)
-    diff_lines = GitDiffer.new(@externals).diff(id, was_files, now_files)
+  def diff_plus(was_files, now_files, options)
+    diff_lines = GitDiffer.new(@externals).diff(was_files, now_files)
     diffs = GitDiffParser.new(diff_lines, options).parse_all
     fill_identical_renamed_files(diffs, now_files, options)
     diffs + unchanged_files(now_files, diffs, options)

--- a/source/server/git_differ.rb
+++ b/source/server/git_differ.rb
@@ -3,12 +3,12 @@ class GitDiffer
     @external = external
   end
 
-  def diff(id, old_files, new_files)
-    Dir.mktmpdir(id, '/tmp') do |git_dir|
+  def diff(old_files, new_files)
+    Dir.mktmpdir('differ', '/tmp') do |git_dir|
       git.setup(git_dir)
       save(git_dir, old_files)
       git.add_commit_tag_0(git_dir)
-      remove_content_from(id, git_dir)
+      remove_content_from(git_dir)
       save(git_dir, new_files)
       git.add_commit_tag_1(git_dir)
       git.diff_0_1(git_dir)
@@ -17,8 +17,8 @@ class GitDiffer
 
   private
 
-  def remove_content_from(id, git_dir)
-    Dir.mktmpdir(id, '/tmp') do |tmp_dir|
+  def remove_content_from(git_dir)
+    Dir.mktmpdir('differ', '/tmp') do |tmp_dir|
       shell.assert_exec(
         "mv #{git_dir}/.git #{tmp_dir}",
         "rm -rf #{git_dir}",

--- a/test/server/lib/coverage_metrics_limits.rb
+++ b/test/server/lib/coverage_metrics_limits.rb
@@ -6,7 +6,7 @@ def metrics
     [ 'test.branches.total' , '<=', 0   ],
     [ 'test.branches.missed', '<=', 0   ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 352 ],
+    [ 'code.lines.total'    , '<=', 356 ],
     [ 'code.lines.missed'   , '<=', 0   ],
     [ 'code.branches.total' , '<=', 62  ],
     [ 'code.branches.missed', '<=', 0   ],


### PR DESCRIPTION
diff_lines and diff_summary now delegate to these new public methods after fetching files from saver, separating file retrieval from diff computation in preparation for the saver refactoring.