### PR TITLE
Fix Docker cleanup, extract slow-tests reporter, set Puma workers to …

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -50,7 +50,11 @@ copy_in_saver_test_data()
 
 containers_down()
 {
-  docker compose down --remove-orphans --volumes
+  local -r all=$(docker ps --all --quiet)
+  if [ -n "${all}" ]; then
+    # shellcheck disable=SC2086
+    docker rm --force ${all}
+  fi
 }
 
 echo_warnings()
@@ -95,10 +99,11 @@ remove_all_but_latest()
   # Keep latest in the cache
   local -r docker_image_ls="${1}"
   local -r name="${2}"
+  docker container prune --force
   for image_name in $(echo "${docker_image_ls}" | grep "${name}:")
   do
     if [ "${image_name}" != "${name}:latest" ]; then
-      docker image rm "${image_name}"
+      docker image rm --force "${image_name}"
     fi
   done
   docker system prune --force

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -64,6 +64,7 @@ check_args()
 run_tests()
 {
   check_args "$@"
+  containers_down
 
   local -r TYPE="${1}"           # {server|client}
   local -r TEST_LOG=test.log

--- a/source/server/config/puma.rb
+++ b/source/server/config/puma.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env puma
+require 'etc'
 
 environment('production')
 rackup("#{__dir__}/config.ru")
+workers(Etc.nprocessors)

--- a/test/client/lib/coverage_metrics_limits.rb
+++ b/test/client/lib/coverage_metrics_limits.rb
@@ -1,7 +1,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 230 ],
+    [ 'test.lines.total'    , '<=', 243 ],
     [ 'test.lines.missed'   , '<=', 0   ],
     [ 'test.branches.total' , '<=', 0   ],
     [ 'test.branches.missed', '<=', 0   ],

--- a/test/client/lib/id58_test_base.rb
+++ b/test/client/lib/id58_test_base.rb
@@ -3,13 +3,15 @@ require 'etc'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require_relative 'slim_json_reporter'
+require_relative 'slow_tests_reporter'
 
 Minitest.parallel_executor = Minitest::Parallel::Executor.new(Etc.nprocessors)
 
 reporters = [
   Minitest::Reporters::DefaultReporter.new,
   Minitest::Reporters::SlimJsonReporter.new,
-  Minitest::Reporters::JUnitReporter.new("#{ENV.fetch('COVERAGE_ROOT')}/junit")
+  Minitest::Reporters::JUnitReporter.new("#{ENV.fetch('COVERAGE_ROOT')}/junit"),
+  Minitest::Reporters::SlowTestsReporter.new
 ]
 Minitest::Reporters.use!(reporters)
 
@@ -28,8 +30,6 @@ class Id58TestBase < Minitest::Test
 
   @@args = (ARGV.sort.uniq - ['--']) # eg 2m4
   @@seen_ids = []
-  @@timings = {}
-  TIMINGS_LOCK = Mutex.new
 
   def self.test(id58, *lines, &test_block)
     src = test_block.source_location
@@ -47,7 +47,7 @@ class Id58TestBase < Minitest::Test
         t1 = Time.now
         instance_eval(&test_block)
         t2 = Time.now
-        TIMINGS_LOCK.synchronize { @@timings["#{id58}:#{src_file}:#{src_line}:#{name58}"] = (t2 - t1) }
+        SlowTestsTimings::LOCK.synchronize { SlowTestsTimings::TIMINGS["#{id58}:#{src_file}:#{src_line}:#{name58}"] = (t2 - t1) }
       ensure
         puts $ERROR_INFO.message unless $ERROR_INFO.nil?
         id58_teardown
@@ -55,19 +55,6 @@ class Id58TestBase < Minitest::Test
     }
     name = "id58 '#{id58}',\n'#{name58}'"
     define_method("test_\n#{name}".to_sym, &execute_around)
-  end
-
-  Minitest.after_run do
-    slow = @@timings.select { |_name, secs| secs > 0.000 }
-    sorted = slow.sort_by { |_name, secs| -secs }.to_h
-    size = [sorted.size, 5].min
-    puts
-    puts 'Slowest tests are...' unless sorted.empty?
-    sorted.each_with_index do |(name, secs), index|
-      puts format('%3.4f - %-72s', secs, name)
-      break if index == size
-    end
-    puts
   end
 
   ID58_ALPHABET = %w[

--- a/test/client/lib/slow_tests_reporter.rb
+++ b/test/client/lib/slow_tests_reporter.rb
@@ -1,0 +1,20 @@
+require 'minitest/reporters'
+
+module SlowTestsTimings
+  TIMINGS = {}
+  LOCK = Mutex.new
+end
+
+class Minitest::Reporters::SlowTestsReporter < Minitest::Reporters::BaseReporter
+  def report
+    # Prints the 5 slowest tests by duration after the full test run.
+    super
+    sorted = SlowTestsTimings::TIMINGS.sort_by { |_name, secs| -secs }.first(5)
+    puts
+    puts 'Slowest tests are...'
+    sorted.each do |(name, secs)|
+      puts format('%3.4f %-72s', secs, name)
+    end
+    puts
+  end
+end

--- a/test/server/lib/coverage_metrics_limits.rb
+++ b/test/server/lib/coverage_metrics_limits.rb
@@ -1,7 +1,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 531 ],
+    [ 'test.lines.total'    , '<=', 544 ],
     [ 'test.lines.missed'   , '<=', 0   ],
     [ 'test.branches.total' , '<=', 0   ],
     [ 'test.branches.missed', '<=', 0   ],

--- a/test/server/lib/id58_test_base.rb
+++ b/test/server/lib/id58_test_base.rb
@@ -3,13 +3,15 @@ require 'etc'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require_relative 'slim_json_reporter'
+require_relative 'slow_tests_reporter'
 
 Minitest.parallel_executor = Minitest::Parallel::Executor.new(Etc.nprocessors)
 
 reporters = [
   Minitest::Reporters::DefaultReporter.new,
   Minitest::Reporters::SlimJsonReporter.new,
-  Minitest::Reporters::JUnitReporter.new("#{ENV.fetch('COVERAGE_ROOT')}/junit")
+  Minitest::Reporters::JUnitReporter.new("#{ENV.fetch('COVERAGE_ROOT')}/junit"),
+  Minitest::Reporters::SlowTestsReporter.new
 ]
 Minitest::Reporters.use!(reporters)
 
@@ -28,8 +30,6 @@ class Id58TestBase < Minitest::Test
 
   @@args = (ARGV.sort.uniq - ['--']) # eg 2m4
   @@seen_ids = []
-  @@timings = {}
-  TIMINGS_LOCK = Mutex.new
 
   def self.test(id58, *lines, &test_block)
     src = test_block.source_location
@@ -47,7 +47,7 @@ class Id58TestBase < Minitest::Test
         t1 = Time.now
         instance_eval(&test_block)
         t2 = Time.now
-        TIMINGS_LOCK.synchronize { @@timings["#{id58}:#{src_file}:#{src_line}:#{name58}"] = (t2 - t1) }
+        SlowTestsTimings::LOCK.synchronize { SlowTestsTimings::TIMINGS["#{id58}:#{src_file}:#{src_line}:#{name58}"] = (t2 - t1) }
       ensure
         puts $ERROR_INFO.message unless $ERROR_INFO.nil?
         id58_teardown
@@ -55,19 +55,6 @@ class Id58TestBase < Minitest::Test
     }
     name = "id58 '#{id58}',\n'#{name58}'"
     define_method("test_\n#{name}".to_sym, &execute_around)
-  end
-
-  Minitest.after_run do
-    slow = @@timings.select { |_name, secs| secs > 0.000 }
-    sorted = slow.sort_by { |_name, secs| -secs }.to_h
-    size = [sorted.size, 5].min
-    puts
-    puts 'Slowest tests are...' unless sorted.empty?
-    sorted.each_with_index do |(name, secs), index|
-      puts format('%3.4f - %-72s', secs, name)
-      break if index == size
-    end
-    puts
   end
 
   ID58_ALPHABET = %w[

--- a/test/server/lib/slow_tests_reporter.rb
+++ b/test/server/lib/slow_tests_reporter.rb
@@ -1,0 +1,20 @@
+require 'minitest/reporters'
+
+module SlowTestsTimings
+  TIMINGS = {}
+  LOCK = Mutex.new
+end
+
+class Minitest::Reporters::SlowTestsReporter < Minitest::Reporters::BaseReporter
+  def report
+    # Prints the 5 slowest tests by duration after the full test run.
+    super
+    sorted = SlowTestsTimings::TIMINGS.sort_by { |_name, secs| -secs }.first(5)
+    puts
+    puts 'Slowest tests are...'
+    sorted.each do |(name, secs)|
+      puts format('%3.4f %-72s', secs, name)
+    end
+    puts
+  end
+end


### PR DESCRIPTION
…nprocessors

containers_down now force-removes all containers across all projects, so ports held by containers from other compose projects (e.g. saver from cyber-dojo/web) no longer block test runs. run_tests.sh calls containers_down at startup so 'make test_server' is self-contained.

Slow-test timing extracted into a dedicated SlowTestsReporter class, matching the pattern already used in cyber-dojo/saver.

Puma configured to spawn one worker per CPU core via Etc.nprocessors.