### PR TITLE
Run CLI sonar scan every second day, and tag it with a version to keep it in sonar longer

### DIFF
--- a/.github/workflows/sonar-for-cli-testing.yml
+++ b/.github/workflows/sonar-for-cli-testing.yml
@@ -116,6 +116,9 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
         uses: SonarSource/sonarqube-scan-action@v6.0.0
+        with:
+          args: >
+            -Dsonar.projectVersion=cli-test-${{ github.run_number }}
 
       # The Kosli CLI integration tests need a valid SonarCloud report-task.txt
       # from a main branch scan. Upload it as an artifact so the CLI tests can download it.

--- a/.github/workflows/sonar-for-cli-testing.yml
+++ b/.github/workflows/sonar-for-cli-testing.yml
@@ -14,7 +14,7 @@ name: SonarCloud for CLI Testing
 
 on:
   schedule:
-    - cron: '0 2 1,15 * *'  # 1st and 15th of each month at 02:00 UTC
+    - cron: '0 2 */2 * *'  # every 2nd day at 02:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- **Run sonar scan every 2nd day since we saw that sonar cleaned out the old scan after 11 days**
- **Tag main scan with sonar.projectVersion to trigger Version events**
