### PR TITLE
Let the differ demo run alongside sibling-repo demos

### DIFF
--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -8,10 +8,19 @@ source "${ROOT_DIR}/bin/echo_env_vars.sh"
 export $(echo_env_vars)
 exit_non_zero_unless_installed docker
 
+# Each demo runs as its own docker-compose project so this repo's demo can
+# run alongside a sibling repo's demo (eg web) without their networks or
+# container names colliding. differ publishes no host ports - the demo execs
+# into the client container, and the client reaches the server over the
+# project's private network. Override to run a second differ demo alongside
+# the first, eg:
+#   COMPOSE_PROJECT_NAME=differ2 bin/demo.sh
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-differ}"
+
 docker compose --progress=plain up --wait --wait-timeout=10 client
 TMP_HTML_FILENAME=/tmp/differ-demo.html
 docker exec \
-  "${CYBER_DOJO_DIFFER_CLIENT_CONTAINER_NAME}" \
+  "$(service_container client)" \
     sh -c 'ruby /differ/source/html_demo.rb' \
       > ${TMP_HTML_FILENAME}
 open "file://${TMP_HTML_FILENAME}"

--- a/bin/echo_env_vars.sh
+++ b/bin/echo_env_vars.sh
@@ -26,9 +26,6 @@ echo_env_vars()
   echo CYBER_DOJO_DIFFER_CLIENT_USER=nobody
   echo CYBER_DOJO_DIFFER_SERVER_USER=nobody
   #
-  echo CYBER_DOJO_DIFFER_CLIENT_CONTAINER_NAME=test_differ_client
-  echo CYBER_DOJO_DIFFER_SERVER_CONTAINER_NAME=test_differ_server
-  #
   local -r AWS_ACCOUNT_ID=244531986313
   local -r AWS_REGION=eu-central-1
   echo CYBER_DOJO_DIFFER_IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/differ"

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -28,6 +28,19 @@ installed()
   fi
 }
 
+service_container()
+{
+  # Echo the container id of the given docker-compose service within this
+  # repo's project. The project is COMPOSE_PROJECT_NAME (set by bin/demo.sh),
+  # defaulting to differ so the test helpers also work against a plain test
+  # run, where Compose derives the same project name from the repo directory.
+  local -r service="${1}"
+  docker ps \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME:-differ}" \
+    --filter "label=com.docker.compose.service=${service}" \
+    --format '{{.ID}}'
+}
+
 stderr()
 {
   local -r message="${1}"
@@ -41,11 +54,11 @@ exit_non_zero()
 
 containers_down()
 {
-  local -r all=$(docker ps --all --quiet)
-  if [ -n "${all}" ]; then
-    # shellcheck disable=SC2086
-    docker rm --force ${all}
-  fi
+  # Tear down only this repo's docker-compose project, leaving any other
+  # repo's running demo untouched. Compose derives the project from
+  # COMPOSE_PROJECT_NAME (or the repo directory name) so this is scoped to
+  # differ's own containers.
+  docker compose down --remove-orphans --volumes
 }
 
 echo_warnings()

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -42,11 +42,9 @@ check_args()
       exit 0
       ;;
     'server')
-      export CONTAINER_NAME="${CYBER_DOJO_DIFFER_SERVER_CONTAINER_NAME}"
       export USER="${CYBER_DOJO_DIFFER_SERVER_USER}"
       ;;
     'client')
-      export CONTAINER_NAME="${CYBER_DOJO_DIFFER_CLIENT_CONTAINER_NAME}"
       export USER="${CYBER_DOJO_DIFFER_CLIENT_USER}"
       ;;
     '')
@@ -75,6 +73,8 @@ run_tests()
   export SERVICE_NAME="${1}"
   # Don't do a build here, because in CI workflow, server image is built with GitHub Action
   docker --log-level=ERROR compose --progress=plain up --no-build --wait --wait-timeout=10 "${SERVICE_NAME}"
+  # Resolve the container now it is up; Compose namespaces it by project+service.
+  export CONTAINER_NAME="$(service_container "${SERVICE_NAME}")"
   echo_warnings "${TYPE}"
 
   echo '=================================='

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,10 @@ services:
       args:
         - COMMIT_SHA
     image: ${CYBER_DOJO_DIFFER_CLIENT_IMAGE}:${CYBER_DOJO_DIFFER_TAG}
-    container_name: ${CYBER_DOJO_DIFFER_CLIENT_CONTAINER_NAME}
     user: ${CYBER_DOJO_DIFFER_CLIENT_USER}
     depends_on:
       - server
     env_file: [ .env ]
-    ports: [ "${CYBER_DOJO_DIFFER_CLIENT_PORT}:${CYBER_DOJO_DIFFER_CLIENT_PORT}" ]
     read_only: true
     restart: no
     volumes:
@@ -32,10 +30,8 @@ services:
       args:
         - COMMIT_SHA
     image: ${CYBER_DOJO_DIFFER_IMAGE}:${CYBER_DOJO_DIFFER_TAG}
-    container_name: ${CYBER_DOJO_DIFFER_SERVER_CONTAINER_NAME}
     user: ${CYBER_DOJO_DIFFER_SERVER_USER}
     env_file: [ .env ]
-    ports: [ "${CYBER_DOJO_DIFFER_PORT}:${CYBER_DOJO_DIFFER_PORT}" ]
     read_only: true
     restart: no
     volumes:


### PR DESCRIPTION
    Until now `make demo` and `make run-tests` brought the client/server up on
    fixed container names and fixed host ports, and the cleanup step ran a
    global `docker rm --force $(docker ps -aq)` that destroyed EVERY container
    on the machine - including any sibling repo's running demo (eg web). So a
    differ demo or test run could not coexist with another repo's demo: they
    fought over host ports and nuked each other. This mirrors the equivalent
    web (#358), creator and dashboard changes for differ.

      - Each demo/test run is its own docker-compose project (COMPOSE_PROJECT_NAME, default differ), so container names are namespaced per project.
      - Publish no host ports at all. The demo execs into the client container and the client reaches the server over the project's private network (by the `server` service name), so nothing needs a host port and nothing collides. - Replace containers_down's global `docker rm --force` nuke with a project-scoped `docker compose down`, so tearing down differ no longer kills the other repos' demos.

    The demo/test helpers no longer assume fixed container names; they resolve a container by compose project+service label via a shared service_container() in lib.sh.

    Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>