### PR TITLE
Switch deploys to kosli-dev/tf for drift detection

### DIFF
--- a/.github/workflows/deploy-manually-to-aws-beta.yml
+++ b/.github/workflows/deploy-manually-to-aws-beta.yml
@@ -29,7 +29,7 @@ jobs:
       aws_region: ${{ steps.vars.outputs.aws_region }}
       gh_actions_iam_role_name: ${{ steps.vars.outputs.gh_actions_iam_role_name }}
     steps:
-    - name: Prepare outputs for fivexl deployment workflow
+    - name: Prepare outputs for the tf deployment workflow
       id: vars
       run: |
         {
@@ -47,13 +47,19 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: fivexl/gh-workflow-tf-plan-apply/.github/workflows/base.yml@v0.0.23
+      pull-requests: read
+    uses: kosli-dev/tf/.github/workflows/apply.yml@main
     with:
       aws_region: ${{ needs.variables.outputs.aws_region }}
       aws_role_arn: arn:aws:iam::${{ needs.variables.outputs.aws_account_id }}:role/${{ needs.variables.outputs.gh_actions_iam_role_name }}
-      aws_default_region: ${{ needs.variables.outputs.aws_region }}
-      aws_role_duration: 900
+      environment: beta
       working_directory: deployment/terraform/
-      tf_apply: 'true'
-      tf_version: v1.9.1
-      tf_additional_env_vars: '{"TF_VAR_TAGGED_IMAGE": "${{ needs.variables.outputs.ecr_registry }}/${{ needs.variables.outputs.service_name }}:${{ needs.variables.outputs.image_tag }}@sha256:${{ needs.variables.outputs.image_fingerprint }}"}'
+      tf_version: v1.14.9
+      tf_vars: |
+        TF_VAR_TAGGED_IMAGE=${{ needs.variables.outputs.ecr_registry }}/${{ needs.variables.outputs.service_name }}:${{ needs.variables.outputs.image_tag }}@sha256:${{ needs.variables.outputs.image_fingerprint }}
+      kosli_host: ${{ vars.KOSLI_HOST }}
+      kosli_org: cyber-dojo
+      kosli_template_file: flow-templates/kosli-apply.yml
+    secrets:
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
+      kosli_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-manually-to-aws-prod.yml
+++ b/.github/workflows/deploy-manually-to-aws-prod.yml
@@ -29,7 +29,7 @@ jobs:
       aws_region: ${{ steps.vars.outputs.aws_region }}
       gh_actions_iam_role_name: ${{ steps.vars.outputs.gh_actions_iam_role_name }}
     steps:
-    - name: Prepare outputs for fivexl deployment workflow
+    - name: Prepare outputs for the tf deployment workflow
       id: vars
       run: |
         {
@@ -47,13 +47,19 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: fivexl/gh-workflow-tf-plan-apply/.github/workflows/base.yml@v0.0.23
+      pull-requests: read
+    uses: kosli-dev/tf/.github/workflows/apply.yml@main
     with:
       aws_region: ${{ needs.variables.outputs.aws_region }}
       aws_role_arn: arn:aws:iam::${{ needs.variables.outputs.aws_account_id }}:role/${{ needs.variables.outputs.gh_actions_iam_role_name }}
-      aws_default_region: ${{ needs.variables.outputs.aws_region }}
-      aws_role_duration: 900
+      environment: prod
       working_directory: deployment/terraform/
-      tf_apply: 'true'
-      tf_version: v1.9.1
-      tf_additional_env_vars: '{"TF_VAR_TAGGED_IMAGE": "${{ needs.variables.outputs.ecr_registry }}/${{ needs.variables.outputs.service_name }}:${{ needs.variables.outputs.image_tag }}@sha256:${{ needs.variables.outputs.image_fingerprint }}"}'
+      tf_version: v1.14.9
+      tf_vars: |
+        TF_VAR_TAGGED_IMAGE=${{ needs.variables.outputs.ecr_registry }}/${{ needs.variables.outputs.service_name }}:${{ needs.variables.outputs.image_tag }}@sha256:${{ needs.variables.outputs.image_fingerprint }}
+      kosli_host: ${{ vars.KOSLI_HOST }}
+      kosli_org: cyber-dojo
+      kosli_template_file: flow-templates/kosli-apply.yml
+    secrets:
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
+      kosli_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,16 +277,22 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: fivexl/gh-workflow-tf-plan-apply/.github/workflows/base.yml@v0.0.23
+      pull-requests: read
+    uses: kosli-dev/tf/.github/workflows/apply.yml@main
     with:
-      aws_region: ${{ needs.setup.outputs.aws_region }}
+      aws_region: eu-central-1
       aws_role_arn: arn:aws:iam::${{ needs.setup.outputs.aws_account_id_beta }}:role/${{ needs.setup.outputs.gh_actions_iam_role_name }}
-      aws_default_region: ${{ needs.setup.outputs.aws_region }}
-      aws_role_duration: 900
+      environment: beta
       working_directory: deployment/terraform/
-      tf_apply: true
-      tf_version: v1.9.1
-      tf_additional_env_vars: '{"TF_VAR_TAGGED_IMAGE": "${{ needs.build-image.outputs.tagged_image_name }}@sha256:${{ needs.build-image.outputs.digest }}"}'
+      tf_version: v1.14.9
+      tf_vars: |
+        TF_VAR_TAGGED_IMAGE=${{ needs.build-image.outputs.tagged_image_name }}@sha256:${{ needs.build-image.outputs.digest }}
+      kosli_host: ${{ vars.KOSLI_HOST }}
+      kosli_org: cyber-dojo
+      kosli_template_file: flow-templates/kosli-apply.yml
+    secrets:
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
+      kosli_github_token: ${{ secrets.GITHUB_TOKEN }}
 
 # Deployment to aws-prod Environment is done with a Release/Promotion workflow.
 # See https://github.com/cyber-dojo/aws-prod-co-promotion

--- a/flow-templates/kosli-apply.yml
+++ b/flow-templates/kosli-apply.yml
@@ -1,0 +1,10 @@
+version: 1
+trail:
+  attestations:
+    - name: terraform-plan
+      type: generic
+    - name: terraform-apply
+      type: generic
+  artifacts:
+    - name: terraform-state
+    - name: drift-plan

--- a/flow-templates/kosli-plan.yml
+++ b/flow-templates/kosli-plan.yml
@@ -1,0 +1,5 @@
+version: 1
+trail:
+  attestations:
+    - name: terraform-plan
+      type: generic


### PR DESCRIPTION
Switch the deploy-to-beta job in main.yml and both manual-deploy workflows (beta and prod) from the FiveXL gh-workflow-tf-plan-apply reusable workflow to kosli-dev/tf/.github/workflows/apply.yml@main, as already done in nginx, runner, saver, web and the other migrated repos.

The motivation is to enable automated drift detection: each apply via the new workflow resets the drift baseline and records Terraform attestations to Kosli.

The manual-deploy workflows attest to Kosli (kosli-apply.yml template) and share the auto-derived terraform-apply-<env>-differ flow with the automated deploy, which is correct as they deploy the same Terraform root.

Add flow-templates/kosli-apply.yml and flow-templates/kosli-plan.yml required by the new workflow.

The tf-environment-reporter.yml workflow is intentionally left on FiveXL for now.